### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -120,7 +120,7 @@ class syntax_plugin_idoit extends DokuWiki_Syntax_Plugin {
 	}
 
 	
-	public function handle($match, $state, $pos, Doku_Handler &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
 		switch ($state) {
 			case DOKU_LEXER_EXIT :
 			case DOKU_LEXER_ENTER :
@@ -134,7 +134,7 @@ class syntax_plugin_idoit extends DokuWiki_Syntax_Plugin {
 		return array($state, null);
 	}
  
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		if ($mode == 'xhtml') {
 			list($state, $match) = $data;
 			switch ($state) {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
